### PR TITLE
Fix race condition

### DIFF
--- a/lib/config/sfConfigCache.class.php
+++ b/lib/config/sfConfigCache.class.php
@@ -335,7 +335,7 @@ class sfConfigCache
     $current_umask = umask(0000);
     if (!is_dir(dirname($cache)))
     {
-      if (false === @mkdir(dirname($cache), 0777, true))
+      if (false === @mkdir(dirname($cache), 0777, true) && !is_dir(dirname($cache)))
       {
         throw new sfCacheException(sprintf('Failed to make cache directory "%s" while generating cache for configuration file "%s".', dirname($cache), $config));
       }

--- a/lib/generator/sfGeneratorManager.class.php
+++ b/lib/generator/sfGeneratorManager.class.php
@@ -83,7 +83,7 @@ class sfGeneratorManager
     if (!is_dir(dirname($path)))
     {
       $current_umask = umask(0000);
-      if (false === @mkdir(dirname($path), 0777, true))
+      if (false === @mkdir(dirname($path), 0777, true) && !is_dir(dirname($path)))
       {
         throw new sfCacheException(sprintf('Failed to make cache directory "%s".', dirname($path)));
       }


### PR DESCRIPTION
It is possible that some other request created the cache-dir between the
is_dir() check and the mkdir() call. So only if the dir doesn't exist
after the mkdir() call we should throw an error
