### PR TITLE
accept local network hostnames in sfValidatorUrl

### DIFF
--- a/lib/validator/sfValidatorUrl.class.php
+++ b/lib/validator/sfValidatorUrl.class.php
@@ -24,6 +24,8 @@ class sfValidatorUrl extends sfValidatorRegex
         ([a-z0-9-]+\.)+[a-z]{2,6}             # a domain name
           |                                   #  or
         \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}    # a IP address
+          |                                   #  or
+        ([a-z0-9-]*)                          # a local network hostname
       )
       (:[0-9]+)?                              # a port (optional)
       (/?|/\S+)                               # a /, nothing or a / with something

--- a/test/unit/validator/sfValidatorUrlTest.php
+++ b/test/unit/validator/sfValidatorUrlTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(15);
+$t = new lime_test(16);
 
 $v = new sfValidatorUrl();
 
@@ -25,6 +25,7 @@ foreach (array(
   'http://127.0.0.1:80/',
   'ftp://google.com/foo.tgz', 
   'ftps://google.com/foo.tgz', 
+  'http://localhost/',
 ) as $url)
 {
   $t->is($v->clean($url), $url, '->clean() checks that the value is a valid URL');


### PR DESCRIPTION
For https://gitlab.recras.nl/recras/recras/issues/5924 , which uncovered that locally resolved hostnames (e.g. "localhost") would be rejected.