### PR TITLE
Test if it's appropriate to call session_set_save_handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,6 @@ matrix:
     fast_finish: true
     allow_failures:
         - php: nightly
-    include:
-        - php: 5.3
-          dist: precise
-          sudo: required
-        - php: 5.4
-          dist: precise
-          sudo: required
 
 # faster builds on new travis setup not using sudo
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 # run build against nightly but allow them to fail

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -65,16 +65,16 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
       throw new sfInitializationException('You must provide a "database" option to sfDatabaseSessionStorage.');
     }
 
-    // use this object as the session handler
-    session_set_save_handler(array($this, 'sessionOpen'),
-                             array($this, 'sessionClose'),
-                             array($this, 'sessionRead'),
-                             array($this, 'sessionWrite'),
-                             array($this, 'sessionDestroy'),
-                             array($this, 'sessionGC'));
+    if (!self::$sessionStarted && php_sapi_name() !== 'cli' && session_status() === PHP_SESSION_NONE) {
+      // use this object as the session handler
+      session_set_save_handler(array($this, 'sessionOpen'),
+        array($this, 'sessionClose'),
+        array($this, 'sessionRead'),
+        array($this, 'sessionWrite'),
+        array($this, 'sessionDestroy'),
+        array($this, 'sessionGC'));
 
-    // start our session
-    if (!self::$sessionStarted) {
+      // start our session
       session_start();
       self::$sessionStarted = true;
     }

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -65,7 +65,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
       throw new sfInitializationException('You must provide a "database" option to sfDatabaseSessionStorage.');
     }
 
-    if (!self::$sessionStarted && php_sapi_name() !== 'cli' && session_status() === PHP_SESSION_NONE) {
+    if (!self::$sessionStarted && session_status() === PHP_SESSION_NONE) {
       // use this object as the session handler
       session_set_save_handler(array($this, 'sessionOpen'),
         array($this, 'sessionClose'),


### PR DESCRIPTION
- only if PHP is not run in CLI mode
- only if the session can be started:
  - Sessions are enabled
  - and there is not a currently started session

Context: https://gitlab.recras.nl/recras/recras/issues/6281