### PR TITLE
PHP 7.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4snapshot
     - nightly
 
 # run build against nightly but allow them to fail

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All the enhancements and BC breaks are listed in the [WHATS_NEW](https://github.
 
 - [DIC](https://github.com/FriendsOfSymfony1/symfony1/wiki/ServiceContainer)
 - Composer support
-- PHP 7.2 support
+- PHP 7.4 support
 - performance boost
 - new widgets & validators
 - some tickets fixed from the symfony trac

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -75,7 +75,7 @@ class sfWebRequest extends sfRequest
     parent::initialize($dispatcher, $parameters, $attributes, $options);
 
     // GET parameters
-    $this->getParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_GET) : $_GET;
+    $this->getParameters = $_GET;
     $this->parameterHolder->add($this->getParameters);
 
     $postParameters = $_POST;
@@ -148,7 +148,7 @@ class sfWebRequest extends sfRequest
       $this->setMethod(self::GET);
     }
 
-    $this->postParameters = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($postParameters) : $postParameters;
+    $this->postParameters = $postParameters;
     $this->parameterHolder->add($this->postParameters);
 
     if ($formats = $this->getOption('formats'))
@@ -600,7 +600,7 @@ class sfWebRequest extends sfRequest
 
     if (isset($_COOKIE[$name]))
     {
-      $retval = get_magic_quotes_gpc() ? sfToolkit::stripslashesDeep($_COOKIE[$name]) : $_COOKIE[$name];
+      $retval = $_COOKIE[$name];
     }
 
     return $retval;

--- a/lib/util/sfFinder.class.php
+++ b/lib/util/sfFinder.class.php
@@ -580,10 +580,10 @@ class sfFinder
 
   public static function isPathAbsolute($path)
   {
-    if ($path{0} === '/' || $path{0} === '\\' ||
-        (strlen($path) > 3 && ctype_alpha($path{0}) &&
-         $path{1} === ':' &&
-         ($path{2} === '\\' || $path{2} === '/')
+    if ($path[0] === '/' || $path[0] === '\\' ||
+        (strlen($path) > 3 && ctype_alpha($path[0]) &&
+         $path[1] === ':' &&
+         ($path[2] === '\\' || $path[2] === '/')
         )
        )
     {


### PR DESCRIPTION
* `get_magic_quotes_gpc` is deprecated. Has been returning `false` since PHP 5.4
* curly brace offset (i.e. `$path{0}`) is deprecated