### PR TITLE
Add level3 phpstan for lib/validator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,9 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[composer.json]
+indent_size = 4
+
+[.travis.yml]
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,6 @@ before_script:
     - composer install
 
 script:
+    - vendor/bin/phpstan analyse -c phpstan.dist.neon
     - php data/bin/check_configuration.php
     - php data/bin/symfony symfony:test --trace

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,17 @@
         "swiftmailer/swiftmailer": "~5.2"
     },
     "require-dev": {
+        "phpstan/phpstan": "^0.12.25",
         "psr/log": "*"
     },
     "type": "library",
     "autoload": {
-        "files": ["autoload.php"]
+        "classmap": [
+            "lib/validator"
+        ],
+        "files": [
+            "autoload.php"
+        ]
     },
     "suggest": {
         "lexpress/doctrine1": "Doctrine plugin",
@@ -22,5 +28,7 @@
             "dev-master": "1.5-dev"
         }
     },
-    "bin": ["data/bin/symfony"]
+    "bin": [
+        "data/bin/symfony"
+    ]
 }

--- a/lib/validator/sfValidatorBase.class.php
+++ b/lib/validator/sfValidatorBase.class.php
@@ -120,7 +120,7 @@ abstract class sfValidatorBase
    * @param string $name   The error code
    * @param string $value  The error message
    *
-   * @return sfValidatorBase The current validator instance
+   * @return $this The current validator instance
    */
   public function addMessage($name, $value)
   {
@@ -135,7 +135,7 @@ abstract class sfValidatorBase
    * @param string $name   The error code
    * @param string $value  The error message
    *
-   * @return sfValidatorBase The current validator instance
+   * @return $this The current validator instance
    */
   public function setMessage($name, $value)
   {
@@ -164,7 +164,7 @@ abstract class sfValidatorBase
    *
    * @param array $values  An array of error messages
    *
-   * @return sfValidatorBase The current validator instance
+   * @return $this The current validator instance
    */
   public function setMessages($values)
   {
@@ -191,7 +191,7 @@ abstract class sfValidatorBase
    * @param string $name   The option name
    * @param mixed  $value  The default value
    *
-   * @return sfValidatorBase The current validator instance
+   * @return $this The current validator instance
    */
   public function addOption($name, $value = null)
   {
@@ -206,7 +206,7 @@ abstract class sfValidatorBase
    * @param string $name   The option name
    * @param mixed  $value  The value
    *
-   * @return sfValidatorBase The current validator instance
+   * @return $this The current validator instance
    */
   public function setOption($name, $value)
   {
@@ -247,7 +247,7 @@ abstract class sfValidatorBase
    *
    * @param array $values  An array of options
    *
-   * @return sfValidatorBase The current validator instance
+   * @return $this The current validator instance
    */
   public function setOptions($values)
   {
@@ -261,7 +261,7 @@ abstract class sfValidatorBase
    *
    * @param string $name  The option name
    *
-   * @return sfValidatorBase The current validator instance
+   * @return $this The current validator instance
    */
   public function addRequiredOption($name)
   {
@@ -478,7 +478,7 @@ abstract class sfValidatorBase
   /**
    * Returns all options with non default values.
    *
-   * @return string  A string representation of the options
+   * @return array<string,mixed>  A string representation of the options
    */
   protected function getOptionsWithoutDefaults()
   {

--- a/lib/validator/sfValidatorDate.class.php
+++ b/lib/validator/sfValidatorDate.class.php
@@ -167,7 +167,7 @@ class sfValidatorDate extends sfValidatorBase
    *
    * @param  array $value  An array of date elements
    *
-   * @return int A timestamp
+   * @return string A timestamp
    */
   protected function convertDateArrayToString($value)
   {

--- a/lib/validator/sfValidatorDecorator.class.php
+++ b/lib/validator/sfValidatorDecorator.class.php
@@ -87,6 +87,7 @@ abstract class sfValidatorDecorator extends sfValidatorBase
   public function setMessage($name, $value)
   {
     $this->validator->setMessage($name, $value);
+    return $this;
   }
 
   /**
@@ -119,6 +120,7 @@ abstract class sfValidatorDecorator extends sfValidatorBase
   public function setOption($name, $value)
   {
     $this->validator->setOption($name, $value);
+    return $this;
   }
 
   /**
@@ -143,6 +145,7 @@ abstract class sfValidatorDecorator extends sfValidatorBase
   public function setOptions($values)
   {
     $this->validator->setOptions($values);
+    return $this;
   }
 
   /**

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -98,7 +98,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Adds a collection of errors.
    *
-   * @param sfValidatorErrorSchema $errorsAn sfValidatorErrorSchema instance
+   * @param sfValidatorErrorSchema $errors An sfValidatorErrorSchema instance
    *
    * @return sfValidatorErrorSchema The current error schema instance
    */

--- a/lib/validator/sfValidatorFile.class.php
+++ b/lib/validator/sfValidatorFile.class.php
@@ -210,7 +210,7 @@ class sfValidatorFile extends sfValidatorBase
    *
    * @param  string $file  The absolute path of a file
    *
-   * @return string The mime type of the file (null if not guessable)
+   * @return string|null The mime type of the file (null if not guessable)
    */
   protected function guessFromFileinfo($file)
   {
@@ -240,7 +240,7 @@ class sfValidatorFile extends sfValidatorBase
    *
    * @param  string $file  The absolute path of a file
    *
-   * @return string The mime type of the file (null if not guessable)
+   * @return string|null The mime type of the file (null if not guessable)
    */
   protected function guessFromMimeContentType($file)
   {
@@ -257,7 +257,7 @@ class sfValidatorFile extends sfValidatorBase
    *
    * @param  string $file  The absolute path of a file
    *
-   * @return string The mime type of the file (null if not guessable)
+   * @return string|null The mime type of the file (null if not guessable)
    */
   protected function guessFromFileBinary($file)
   {
@@ -309,7 +309,7 @@ class sfValidatorFile extends sfValidatorBase
   /**
    * Returns the maximum size of an uploaded file as configured in php.ini
    *
-   * @return type The maximum size of an uploaded file in bytes
+   * @return int The maximum size of an uploaded file in bytes
    */
   protected function getMaxFilesize()
   {

--- a/lib/validator/sfValidatorFromDescription.class.php
+++ b/lib/validator/sfValidatorFromDescription.class.php
@@ -330,6 +330,8 @@ class sfValidatorFDTokenFilter
 
 class sfValidatorFDTokenOperator
 {
+  /** @var array */
+  protected $arguments;
   protected
     $class,
     $operator,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Variable \\$cleanTime might not be defined\\.$#"
+			count: 2
+			path: lib/validator/sfValidatorDate.class.php
+

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,3 @@
+includes:
+    - phpstan.neon
+    - phpstan-baseline.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+  level: 3
+  paths:
+    - lib/validator


### PR DESCRIPTION
Some of the code is such a hot mess that whitelist-enabling is the way to go.

I chose PHPstan level 3 more or less randomly, I think it allows us to strike a good balance between strictness and being able to fix issues with doc comments.