### PR TITLE
Remove swiftmailer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "lib/vendor/swiftmailer"]
-	path = lib/vendor/swiftmailer
-	url = https://github.com/swiftmailer/swiftmailer.git
-	branch = 5.x
 [submodule "lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine"]
 	path = lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine
 	url = https://github.com/LExpress/doctrine1.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ services:
 # cache vendor dirs
 cache:
     directories:
-        - lib/vendor/swiftmailer
         - $HOME/.composer/cache
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Fork of symfony 1.4, based on lexpress/symfony1",
     "license": "MIT",
     "require": {
-        "swiftmailer/swiftmailer": "~5.2"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.25",


### PR DESCRIPTION
We already removed the mailer component some time ago, so no need to keep swiftmailer in here. This means we must now require swiftmailer from our main repo. 
Since this is a breaking change, we should probably release a new major version.