### PR TITLE
Throw on invalid json data

### DIFF
--- a/lib/action/sfAction.class.php
+++ b/lib/action/sfAction.class.php
@@ -262,7 +262,7 @@ abstract class sfAction extends sfComponent
   public function renderJson($data)
   {
     $this->getResponse()->setContentType('application/json');
-    $this->getResponse()->setContent(json_encode($data));
+    $this->getResponse()->setContent(json_encode($data, JSON_THROW_ON_ERROR));
 
     return sfView::NONE;
   }


### PR DESCRIPTION
We had some issues where invalid data resulted in an empty page without an error.