### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine"]
 	path = lib/plugins/sfDoctrinePlugin/lib/vendor/doctrine
-	url = https://github.com/LExpress/doctrine1.git
+	url = https://github.com/Recras/doctrine1.git

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Fork of symfony 1.4, based on lexpress/symfony1",
     "license": "MIT",
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.25",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Fork of symfony 1.4, based on lexpress/symfony1",
     "license": "MIT",
     "require": {
+        "php": ">=7.4"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.25",

--- a/lib/addon/sfPager.class.php
+++ b/lib/addon/sfPager.class.php
@@ -529,7 +529,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
-  public function current()
+  public function current(): mixed
   {
     if (!$this->isIteratorInitialized())
     {
@@ -544,7 +544,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
-  public function key()
+  public function key(): string
   {
     if (!$this->isIteratorInitialized())
     {
@@ -559,7 +559,7 @@ abstract class sfPager implements Iterator, Countable
    *
    * @see Iterator
    */
-  public function next()
+  public function next(): void
   {
     if (!$this->isIteratorInitialized())
     {
@@ -568,7 +568,7 @@ abstract class sfPager implements Iterator, Countable
 
     --$this->resultsCounter;
 
-    return next($this->results);
+    next($this->results);
   }
 
   /**

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -42,7 +42,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->value);
 
@@ -54,7 +54,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return string The key
    */
-  public function key()
+  public function key(): string
   {
     return key($this->value);
   }
@@ -67,7 +67,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, current($this->value));
   }
@@ -75,7 +75,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
-  public function next()
+  public function next(): void
   {
     next($this->value);
 
@@ -91,7 +91,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool The validity of the current element; true if it is valid
    */
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -103,7 +103,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return bool true if the offset isset; false otherwise
    */
-  public function offsetExists($offset)
+  public function offsetExists(mixed $offset): bool
   {
     return isset($this->value[$offset]);
   }
@@ -115,7 +115,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return mixed The escaped value
    */
-  public function offsetGet($offset)
+  public function offsetGet(mixed $offset): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
   }
@@ -148,7 +148,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  public function offsetUnset($offset)
+  public function offsetUnset(mixed $offset): void
   {
     throw new sfException('Cannot unset values.');
   }
@@ -158,7 +158,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @return int The size of the array
    */
-  public function count()
+  public function count(): int
   {
     return count($this->value);
   }

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -132,7 +132,7 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    *
    * @throws sfException
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new sfException('Cannot set values.');
   }

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -138,7 +138,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new sfException('Cannot set values.');
   }

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -154,7 +154,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @throws sfException
    */
-  public function offsetUnset($offset)
+  public function offsetUnset(mixed $offset): void
   {
     throw new sfException('Cannot unset values.');
   }

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -56,9 +56,9 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return void
    */
-  public function rewind()
+  public function rewind(): void
   {
-    return $this->iterator->rewind();
+    $this->iterator->rewind();
   }
 
   /**
@@ -66,7 +66,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->iterator->current());
   }
@@ -76,7 +76,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return string Iterator key
    */
-  public function key()
+  public function key(): string
   {
     return $this->iterator->key();
   }
@@ -86,9 +86,9 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return void
    */
-  public function next()
+  public function next(): void
   {
-    return $this->iterator->next();
+    $this->iterator->next();
   }
 
   /**

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -97,7 +97,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the current element is valid; false otherwise
    */
-  public function valid()
+  public function valid(): bool
   {
     return $this->iterator->valid();
   }
@@ -109,7 +109,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return bool true if the offset isset; false otherwise
    */
-  public function offsetExists($offset)
+  public function offsetExists($offset): bool
   {
     return isset($this->value[$offset]);
   }
@@ -121,7 +121,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
    *
    * @return mixed The escaped value
    */
-  public function offsetGet($offset)
+  public function offsetGet(mixed $offset): mixed
   {
     return sfOutputEscaper::escape($this->escapingMethod, $this->value[$offset]);
   }

--- a/lib/escaper/sfOutputEscaperObjectDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperObjectDecorator.class.php
@@ -90,20 +90,16 @@ class sfOutputEscaperObjectDecorator extends sfOutputEscaperGetterDecorator impl
 
   /**
    * Try to call decorated object __toString() method if exists.
-   *
-   * @return string
    */
-  public function __toString()
+  public function __toString(): string
   {
     return $this->escape($this->escapingMethod, (string) $this->value);
   }
 
   /**
    * Asks the wrapped object whether a property is set.
-   *
-   * @return boolean
    */
-  public function __isset($key)
+  public function __isset($key): bool
   {
     return isset($this->value->$key);
   }
@@ -115,7 +111,7 @@ class sfOutputEscaperObjectDecorator extends sfOutputEscaperGetterDecorator impl
    *
    * @return int The size of the object
    */
-  public function count()
+  public function count(): int
   {
     return count($this->value);
   }

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -117,7 +117,7 @@ class sfEvent implements ArrayAccess
    *
    * @return Boolean true if the parameter exists, false otherwise
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return array_key_exists($name, $this->parameters);
   }

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -129,7 +129,7 @@ class sfEvent implements ArrayAccess
    *
    * @return mixed  The parameter value
    */
-  public function offsetGet($name): mixed
+  public function offsetGet(mixed $name): mixed
   {
     if (!array_key_exists($name, $this->parameters))
     {

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -145,7 +145,7 @@ class sfEvent implements ArrayAccess
    * @param string  $name   The parameter name
    * @param mixed   $value  The parameter value
    */
-  public function offsetSet($name, $value)
+  public function offsetSet($name, $value): void
   {
     $this->parameters[$name] = $value;
   }

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -129,7 +129,7 @@ class sfEvent implements ArrayAccess
    *
    * @return mixed  The parameter value
    */
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     if (!array_key_exists($name, $this->parameters))
     {

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -155,7 +155,7 @@ class sfEvent implements ArrayAccess
    *
    * @param string $name    The parameter name
    */
-  public function offsetUnset(string $name): void
+  public function offsetUnset(mixed $name): void
   {
     unset($this->parameters[$name]);
   }

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -155,7 +155,7 @@ class sfEvent implements ArrayAccess
    *
    * @param string $name    The parameter name
    */
-  public function offsetUnset($name)
+  public function offsetUnset($name): void
   {
     unset($this->parameters[$name]);
   }

--- a/lib/event/sfEvent.class.php
+++ b/lib/event/sfEvent.class.php
@@ -155,7 +155,7 @@ class sfEvent implements ArrayAccess
    *
    * @param string $name    The parameter name
    */
-  public function offsetUnset($name): void
+  public function offsetUnset(string $name): void
   {
     unset($this->parameters[$name]);
   }

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1126,7 +1126,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param string $offset The field name
    */
-  public function offsetUnset($offset): void
+  public function offsetUnset(string $offset): void
   {
     unset(
       $this->widgetSchema[$offset],

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1126,7 +1126,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param string $offset The field name
    */
-  public function offsetUnset(string $offset): void
+  public function offsetUnset(mixed $offset): void
   {
     unset(
       $this->widgetSchema[$offset],

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1258,7 +1258,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
-  public function next(): mixed
+  public function next(): void
   {
     next($this->fieldNames);
     --$this->count;

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1227,7 +1227,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     $this->fieldNames = $this->widgetSchema->getPositions();
 
@@ -1240,7 +1240,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return string The key
    */
-  public function key()
+  public function key(): string
   {
     return current($this->fieldNames);
   }
@@ -1269,7 +1269,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return boolean The validity of the current element; true if it is valid
    */
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -1279,7 +1279,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return integer The number of embedded form fields
    */
-  public function count()
+  public function count(): int
   {
     return count($this->getFormFieldSchema());
   }

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1076,7 +1076,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return sfFormField|sfFormFieldSchema A form field instance
    */
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     if (!isset($this->formFields[$name]))
     {
@@ -1114,7 +1114,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @throws <b>LogicException</b>
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new LogicException('Cannot update form fields.');
   }
@@ -1126,7 +1126,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param string $offset The field name
    */
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     unset(
       $this->widgetSchema[$offset],
@@ -1250,7 +1250,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return $this[current($this->fieldNames)];
   }
@@ -1258,7 +1258,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
-  public function next()
+  public function next(): mixed
   {
     next($this->fieldNames);
     --$this->count;

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1076,7 +1076,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return sfFormField|sfFormFieldSchema A form field instance
    */
-  public function offsetGet($name): mixed
+  public function offsetGet(mixed $name): mixed
   {
     if (!isset($this->formFields[$name]))
     {

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -1064,7 +1064,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @return Boolean true if the widget exists, false otherwise
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->widgetSchema[$name]);
   }

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -156,7 +156,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @throws LogicException
    */
-  public function offsetUnset($offset)
+  public function offsetUnset(mixed $offset): void
   {
     throw new LogicException('Cannot remove form fields (read-only).');
   }

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -164,7 +164,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Resets the field names array to the beginning (implements the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->fieldNames);
     $this->count = count($this->fieldNames);
@@ -175,7 +175,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return string The key
    */
-  public function key()
+  public function key(): string
   {
     return current($this->fieldNames);
   }
@@ -185,7 +185,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return $this[current($this->fieldNames)];
   }
@@ -193,7 +193,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
   /**
    * Moves to the next form field (implements the Iterator interface).
    */
-  public function next()
+  public function next(): void
   {
     next($this->fieldNames);
     --$this->count;

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -144,7 +144,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @throws LogicException
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new LogicException('Cannot update form fields (read-only).');
   }

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -103,7 +103,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    *
    * @return sfFormField A form field instance
    */
-  public function offsetGet($name)
+  public function offsetGet(mixed $name): sfFormField
   {
     if (!isset($this->fields[$name]))
     {

--- a/lib/i18n/sfDateFormat.class.php
+++ b/lib/i18n/sfDateFormat.class.php
@@ -239,7 +239,7 @@ class sfDateFormat
       }
       else
       {
-        $function = ucfirst($this->getFunctionName($pattern));
+        $function = ucfirst($this->getFunctionName($pattern) ?? '');
         if ($function != null)
         {
           $fName = 'get'.$function;
@@ -270,6 +270,7 @@ class sfDateFormat
     {
       return $this->tokens[$token[0]];
     }
+    return null;
   }
 
   /**

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -21,7 +21,7 @@ class sfFileLogger extends sfLogger
   protected
     $type       = 'symfony',
     $format     = '%time% %type% [%priority%] %message%%EOL%',
-    $timeFormat = '%b %d %H:%M:%S',
+    $timeFormat = 'M d H:i:s',
     $fp         = null;
 
   /**
@@ -32,7 +32,7 @@ class sfFileLogger extends sfLogger
    * - file:        The file path or a php wrapper to log messages
    *                You can use any support php wrapper. To write logs to the Apache error log, use php://stderr
    * - format:      The log line format (default to %time% %type% [%priority%] %message%%EOL%)
-   * - time_format: The log time strftime format (default to %b %d %H:%M:%S)
+   * - time_format: The log time date format (default to M d H:i:s)
    * - dir_mode:    The mode to use when creating a directory (default to 0777)
    * - file_mode:   The mode to use when creating a file (default to 0666)
    *
@@ -100,7 +100,7 @@ class sfFileLogger extends sfLogger
     fwrite($this->fp, strtr($this->format, array(
       '%type%'     => $this->type,
       '%message%'  => $message,
-      '%time%'     => strftime($this->timeFormat),
+      '%time%'     => date($this->timeFormat),
       '%priority%' => $this->getPriority($priority),
       '%EOL%'      => PHP_EOL,
     )));

--- a/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionProfiler.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionProfiler.class.php
@@ -200,7 +200,7 @@ class sfDoctrineConnectionProfiler extends Doctrine_Connection_Profiler
 
     foreach ($params as $key => $param)
     {
-      if (strlen($param) >= 255)
+      if (!is_null($param) && strlen($param) >= 255)
       {
         $params[$key] = '['.number_format(strlen($param) / 1024, 2).'Kb]';
       }

--- a/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
@@ -349,7 +349,7 @@ class sfDoctrineColumn implements ArrayAccess
     return $this->table;
   }
 
-  public function offsetExists($offset)
+  public function offsetExists(mixed $offset): bool
   {
     return isset($this->definition[$offset]);
   }
@@ -364,7 +364,7 @@ class sfDoctrineColumn implements ArrayAccess
     return $this->definition[$offset];
   }
 
-  public function offsetUnset($offset)
+  public function offsetUnset(mixed $offset): void
   {
     unset($this->definition[$offset]);
   }

--- a/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/generator/sfDoctrineColumn.class.php
@@ -354,12 +354,12 @@ class sfDoctrineColumn implements ArrayAccess
     return isset($this->definition[$offset]);
   }
 
-  public function offsetSet($offset, $value)
+  public function offsetSet(mixed $offset, mixed $value): void
   {
     $this->definition[$offset] = $value;
   }
 
-  public function offsetGet($offset)
+  public function offsetGet(mixed $offset): mixed
   {
     return $this->definition[$offset];
   }

--- a/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
@@ -17,7 +17,7 @@
  * @author     Jonathan H. Wage <jonwage@gmail.com>
  * @version    SVN: $Id$
  */
-class sfDoctrinePager extends sfPager implements Serializable
+class sfDoctrinePager extends sfPager
 {
   protected
     $query             = null,
@@ -50,7 +50,7 @@ class sfDoctrinePager extends sfPager implements Serializable
    *
    * @return string $serialized
    */
-  public function serialize()
+  public function __serialize()
   {
     $vars = get_object_vars($this);
     unset($vars['query']);
@@ -62,7 +62,7 @@ class sfDoctrinePager extends sfPager implements Serializable
    *
    * @param string $serialized
    */
-  public function unserialize($serialized)
+  public function __unserialize($serialized)
   {
     $array = unserialize($serialized);
 
@@ -71,7 +71,7 @@ class sfDoctrinePager extends sfPager implements Serializable
       $this->$name = $values;
     }
 
-    $this->tableMethodCalled = false; 
+    $this->tableMethodCalled = false;
   }
 
   /**

--- a/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
@@ -45,23 +45,19 @@ class sfDoctrinePager extends sfPager
     $this->tableMethodName = $tableMethodName;
   }
 
-  public function __serialize(): string
+  public function __serialize(): array
   {
     $vars = get_object_vars($this);
     unset($vars['query']);
-    return serialize($vars);
+    return $vars;
   }
 
   /**
    * Unserialize a pager object
-   *
-   * @param string $serialized
    */
-  public function __unserialize($serialized)
+  public function __unserialize(array $serialized)
   {
-    $array = unserialize($serialized);
-
-    foreach ($array as $name => $values)
+    foreach ($serialized as $name => $values)
     {
       $this->$name = $values;
     }

--- a/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/pager/sfDoctrinePager.class.php
@@ -45,12 +45,7 @@ class sfDoctrinePager extends sfPager
     $this->tableMethodName = $tableMethodName;
   }
 
-  /**
-   * Serialize the pager object
-   *
-   * @return string $serialized
-   */
-  public function __serialize()
+  public function __serialize(): string
   {
     $vars = get_object_vars($this);
     unset($vars['query']);

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -185,7 +185,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @return mixed The request parameter if exists, null otherwise
    */
-  public function offsetGet($name): mixed
+  public function offsetGet(mixed $name): mixed
   {
     return $this->getParameter($name, false);
   }

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -206,7 +206,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  public function offsetUnset($offset): void
+  public function offsetUnset(mixed $offset): void
   {
     $this->getParameterHolder()->remove($offset);
   }

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -196,7 +196,7 @@ abstract class sfRequest implements ArrayAccess
    * @param string $offset The parameter name
    * @param string $value The parameter value
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     $this->setParameter($offset, $value);
   }

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -206,7 +206,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     $this->getParameterHolder()->remove($offset);
   }

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -173,7 +173,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @return Boolean true if the request parameter exists, false otherwise
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return $this->hasParameter($name);
   }

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -185,7 +185,7 @@ abstract class sfRequest implements ArrayAccess
    *
    * @return mixed The request parameter if exists, null otherwise
    */
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return $this->getParameter($name, false);
   }

--- a/lib/response/sfResponse.class.php
+++ b/lib/response/sfResponse.class.php
@@ -17,7 +17,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
  */
-abstract class sfResponse implements Serializable
+abstract class sfResponse
 {
   /** @var array */
   protected $options = array();
@@ -154,7 +154,7 @@ abstract class sfResponse implements Serializable
    *
    * @return array Objects instance
    */
-  public function serialize()
+  public function __serialize()
   {
     return serialize($this->content);
   }

--- a/lib/response/sfResponse.class.php
+++ b/lib/response/sfResponse.class.php
@@ -152,9 +152,11 @@ abstract class sfResponse
   /**
    * Serializes the current instance.
    */
-  public function __serialize(): string
+  public function __serialize(): array
   {
-    return serialize($this->content);
+    return [
+      'content' => $this->content,
+    ];
   }
 
   /**
@@ -162,11 +164,9 @@ abstract class sfResponse
    *
    * You need to inject a dispatcher after unserializing a sfResponse instance.
    *
-   * @param string $serialized  A serialized sfResponse instance
-   *
    */
-  public function unserialize($serialized)
+  public function __unserialize(array $serialized)
   {
-    $this->content = unserialize($serialized);
+    $this->content = $serialized['content'];
   }
 }

--- a/lib/response/sfResponse.class.php
+++ b/lib/response/sfResponse.class.php
@@ -151,10 +151,8 @@ abstract class sfResponse
 
   /**
    * Serializes the current instance.
-   *
-   * @return array Objects instance
    */
-  public function __serialize()
+  public function __serialize(): string
   {
     return serialize($this->content);
   }

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -874,18 +874,28 @@ class sfWebResponse extends sfResponse
   /**
    * @see sfResponse
    */
-  public function __serialize(): string
+  public function __serialize(): array
   {
-    return serialize(array($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots));
+    return [
+      'content' => $this->content,
+      'statusCode' => $this->statusCode,
+      'statusText' => $this->statusText,
+      'options' => $this->options,
+      'headerOnly' => $this->headerOnly,
+      'headers' => $this->headers,
+      'metas' => $this->metas,
+      'httpMetas' => $this->httpMetas,
+      'stylesheets' => $this->stylesheets,
+      'javascripts' => $this->javascripts,
+      'slots' => $this->slots,
+    ];
   }
 
-  /**
-   * @see sfResponse
-   * @inheritdoc
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $serialized)
   {
-    list($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots) = unserialize($serialized);
+    foreach ($serialized as $name => $values) {
+      $this->$name = $values;
+    }
   }
 
   /**

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -874,7 +874,7 @@ class sfWebResponse extends sfResponse
   /**
    * @see sfResponse
    */
-  public function __serialize()
+  public function __serialize(): string
   {
     return serialize(array($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots));
   }

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -874,7 +874,7 @@ class sfWebResponse extends sfResponse
   /**
    * @see sfResponse
    */
-  public function serialize()
+  public function __serialize()
   {
     return serialize(array($this->content, $this->statusCode, $this->statusText, $this->options, $this->headerOnly, $this->headers, $this->metas, $this->httpMetas, $this->stylesheets, $this->javascripts, $this->slots));
   }

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -19,7 +19,7 @@
  * @property $firstOptional int
  * @property $segments array
  */
-class sfRoute implements Serializable
+class sfRoute
 {
   protected
     $isBound           = false,
@@ -845,7 +845,7 @@ class sfRoute implements Serializable
     }
   }
 
-  public function serialize()
+  public function __serialize()
   {
     // always serialize compiled routes
     $this->compile();

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -845,17 +845,31 @@ class sfRoute
     }
   }
 
-  public function __serialize(): string
+  public function __serialize(): array
   {
     // always serialize compiled routes
     $this->compile();
     // sfPatternRouting will always re-set defaultParameters, so no need to serialize them
-    return serialize(array($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken));
+    return [
+      'tokens' => $this->tokens,
+      'defaultOptions' => $this->defaultOptions,
+      'options' => $this->options,
+      'pattern' => $this->pattern,
+      'staticPrefix' => $this->staticPrefix,
+      'regex' => $this->regex,
+      'variables' => $this->variables,
+      'defaults' => $this->defaults,
+      'requirements' => $this->requirements,
+      'suffix' => $this->suffix,
+      'customToken' => $this->customToken,
+    ];
   }
 
-  public function unserialize($data)
+  public function __unserialize(array $serialized)
   {
-    list($this->tokens, $this->defaultOptions, $this->options, $this->pattern, $this->staticPrefix, $this->regex, $this->variables, $this->defaults, $this->requirements, $this->suffix, $this->customToken) = unserialize($data);
+    foreach ($serialized as $name => $values) {
+      $this->$name = $values;
+    }
     $this->compiled = true;
   }
 }

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -845,7 +845,7 @@ class sfRoute
     }
   }
 
-  public function __serialize()
+  public function __serialize(): string
   {
     // always serialize compiled routes
     $this->compile();

--- a/lib/routing/sfRouteCollection.class.php
+++ b/lib/routing/sfRouteCollection.class.php
@@ -61,7 +61,7 @@ class sfRouteCollection implements Iterator
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->routes);
 
@@ -73,7 +73,7 @@ class sfRouteCollection implements Iterator
    *
    * @return string The key
    */
-  public function key()
+  public function key(): string
   {
     return key($this->routes);
   }
@@ -83,7 +83,7 @@ class sfRouteCollection implements Iterator
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return current($this->routes);
   }
@@ -91,7 +91,7 @@ class sfRouteCollection implements Iterator
   /**
    * Moves to the next route (implements the Iterator interface).
    */
-  public function next()
+  public function next(): void
   {
     next($this->routes);
 
@@ -103,7 +103,7 @@ class sfRouteCollection implements Iterator
    *
    * @return boolean The validity of the current route; true if it is valid
    */
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -227,7 +227,7 @@ class sfUser implements ArrayAccess
    *
    * @return Boolean true if the user attribute exists, false otherwise
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return $this->hasAttribute($name);
   }
@@ -260,7 +260,7 @@ class sfUser implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     $this->getAttributeHolder()->remove($offset);
   }

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -260,7 +260,7 @@ class sfUser implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  public function offsetUnset($offset): void
+  public function offsetUnset(mixed $offset): void
   {
     $this->getAttributeHolder()->remove($offset);
   }

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -250,7 +250,7 @@ class sfUser implements ArrayAccess
    * @param string $offset The parameter name
    * @param string $value The parameter value
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     $this->setAttribute($offset, $value);
   }

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -239,7 +239,7 @@ class sfUser implements ArrayAccess
    *
    * @return mixed The user attribute if exists, null otherwise
    */
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return $this->getAttribute($name, false);
   }

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -239,7 +239,7 @@ class sfUser implements ArrayAccess
    *
    * @return mixed The user attribute if exists, null otherwise
    */
-  public function offsetGet($name): mixed
+  public function offsetGet(mixed $name): mixed
   {
     return $this->getAttribute($name, false);
   }

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -515,7 +515,7 @@ class sfContext implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  public function offsetUnset($offset): void
+  public function offsetUnset(mixed $offset): void
   {
     unset($this->factories[$offset]);
   }

--- a/lib/util/sfContext.class.php
+++ b/lib/util/sfContext.class.php
@@ -482,7 +482,7 @@ class sfContext implements ArrayAccess
    *
    * @return Boolean true if the context object exists, false otherwise
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return $this->has($name);
   }
@@ -494,7 +494,7 @@ class sfContext implements ArrayAccess
    *
    * @return mixed The context object if exists, null otherwise
    */
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return $this->get($name);
   }
@@ -505,7 +505,7 @@ class sfContext implements ArrayAccess
    * @param string $offset Service name
    * @param mixed  $value Service
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     $this->set($offset, $value);
   }
@@ -515,7 +515,7 @@ class sfContext implements ArrayAccess
    *
    * @param string $offset The parameter name
    */
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
     unset($this->factories[$offset]);
   }

--- a/lib/util/sfDomCssSelector.class.php
+++ b/lib/util/sfDomCssSelector.class.php
@@ -563,7 +563,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Reset the array to the beginning (as required for the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->nodes);
 
@@ -575,7 +575,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return string The key
    */
-  public function key()
+  public function key(): string
   {
     return key($this->nodes);
   }
@@ -585,7 +585,7 @@ class sfDomCssSelector implements Countable, Iterator
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return current($this->nodes);
   }
@@ -593,7 +593,7 @@ class sfDomCssSelector implements Countable, Iterator
   /**
    * Moves to the next element (as required by the Iterator interface).
    */
-  public function next()
+  public function next(): void
   {
     next($this->nodes);
 

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -368,7 +368,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    *
    * @return array Objects instance
    */
-  public function serialize()
+  public function __serialize()
   {
     return serialize(array($this->default_namespace, $this->parameters));
   }

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -365,10 +365,8 @@ class sfNamespacedParameterHolder extends sfParameterHolder
 
   /**
    * Serializes the current instance.
-   *
-   * @return array Objects instance
    */
-  public function __serialize()
+  public function __serialize(): string
   {
     return serialize(array($this->default_namespace, $this->parameters));
   }

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -366,21 +366,20 @@ class sfNamespacedParameterHolder extends sfParameterHolder
   /**
    * Serializes the current instance.
    */
-  public function __serialize(): string
+  public function __serialize(): array
   {
-    return serialize(array($this->default_namespace, $this->parameters));
+    return [
+      'default_namespace' => $this->default_namespace,
+      'parameters' => $this->parameters,
+    ];
   }
 
   /**
    * Unserializes a sfNamespacedParameterHolder instance.
-   *
-   * @param string $serialized  A serialized sfNamespacedParameterHolder instance
    */
-  public function unserialize($serialized)
+  public function __unserialize(array $data)
   {
-    $data = unserialize($serialized);
-
-    $this->default_namespace = $data[0];
-    $this->parameters = $data[1];
+    $this->default_namespace = $data['default_namespace'];
+    $this->parameters = $data['parameters'];
   }
 }

--- a/lib/util/sfParameterHolder.class.php
+++ b/lib/util/sfParameterHolder.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,7 +21,7 @@
  * @author     Sean Kerr <sean@code-box.org>
  * @version    SVN: $Id$
  */
-class sfParameterHolder implements Serializable
+class sfParameterHolder
 {
   protected $parameters = array();
 
@@ -183,7 +183,7 @@ class sfParameterHolder implements Serializable
    *
    * @return array Objects instance
    */
-  public function serialize()
+  public function __serialize()
   {
     return serialize($this->parameters);
   }

--- a/lib/util/sfParameterHolder.class.php
+++ b/lib/util/sfParameterHolder.class.php
@@ -180,10 +180,8 @@ class sfParameterHolder
 
   /**
    * Serializes the current instance.
-   *
-   * @return array Objects instance
    */
-  public function __serialize()
+  public function __serialize(): string
   {
     return serialize($this->parameters);
   }

--- a/lib/util/sfParameterHolder.class.php
+++ b/lib/util/sfParameterHolder.class.php
@@ -181,18 +181,18 @@ class sfParameterHolder
   /**
    * Serializes the current instance.
    */
-  public function __serialize(): string
+  public function __serialize(): array
   {
-    return serialize($this->parameters);
+    return [
+      'parameters' => $this->parameters,
+    ];
   }
 
   /**
    * Unserializes a sfParameterHolder instance.
-   *
-   * @param string $serialized  A serialized sfParameterHolder instance
    */
-  public function unserialize($serialized)
+  public function __unserialize(array $serialized)
   {
-    $this->parameters = unserialize($serialized);
+    $this->parameters = $serialized['parameters'];
   }
 }

--- a/lib/validator/sfValidatorError.class.php
+++ b/lib/validator/sfValidatorError.class.php
@@ -16,7 +16,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
  */
-class sfValidatorError extends Exception implements Serializable
+class sfValidatorError extends Exception
 {
   protected
     $validator = null,
@@ -109,7 +109,7 @@ class sfValidatorError extends Exception implements Serializable
    * error messages:
    *
    * $i18n->__($error->getMessageFormat(), $error->getArguments());
-   * 
+   *
    * If no message format has been set in the validator, the exception standard
    * message is returned.
    *
@@ -138,7 +138,7 @@ class sfValidatorError extends Exception implements Serializable
    *
    * @return string The instance as a serialized string
    */
-  public function serialize()
+  public function __serialize()
   {
     return serialize(array($this->validator, $this->arguments, $this->code, $this->message));
   }

--- a/lib/validator/sfValidatorError.class.php
+++ b/lib/validator/sfValidatorError.class.php
@@ -138,7 +138,7 @@ class sfValidatorError extends Exception
    *
    * @return string The instance as a serialized string
    */
-  public function __serialize()
+  public function __serialize(): string
   {
     return serialize(array($this->validator, $this->arguments, $this->code, $this->message));
   }

--- a/lib/validator/sfValidatorError.class.php
+++ b/lib/validator/sfValidatorError.class.php
@@ -136,21 +136,22 @@ class sfValidatorError extends Exception
    * the trace can contain a PDO instance which is not serializable, serializing won't
    * work when using PDO.
    *
-   * @return string The instance as a serialized string
+   * @return array The instance as a serialized string
    */
-  public function __serialize(): string
+  public function __serialize(): array
   {
-    return serialize(array($this->validator, $this->arguments, $this->code, $this->message));
+    return [
+      'validator' => $this->validator,
+      'arguments' => $this->arguments,
+      'code' => $this->code,
+      'message' => $this->message,
+    ];
   }
 
-  /**
-   * Unserializes a sfValidatorError instance.
-   *
-   * @param string $serialized  A serialized sfValidatorError instance
-   *
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $serialized)
   {
-    list($this->validator, $this->arguments, $this->code, $this->message) = unserialize($serialized);
+    foreach ($serialized as $name => $values) {
+      $this->$name = $values;
+    }
   }
 }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -273,7 +273,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @param string $offset  (ignored)
    */
-  public function offsetUnset($offset): void
+  public function offsetUnset(mixed $offset): void
   {
   }
 

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -176,7 +176,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return int The number of array
    */
-  public function count()
+  public function count(): int
   {
     return count($this->errors);
   }
@@ -184,7 +184,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Reset the error array to the beginning (implements the Iterator interface).
    */
-  public function rewind()
+  public function rewind(): void
   {
     reset($this->errors);
 
@@ -206,7 +206,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return mixed The escaped value
    */
-  public function current()
+  public function current(): mixed
   {
     return current($this->errors);
   }
@@ -214,7 +214,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Moves to the next error (implements the Iterator interface).
    */
-  public function next()
+  public function next(): void
   {
     next($this->errors);
 
@@ -226,7 +226,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return boolean The validity of the current element; true if it is valid
    */
-  public function valid()
+  public function valid(): bool
   {
     return $this->count > 0;
   }
@@ -238,7 +238,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return bool true if the error exists, false otherwise
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->errors[$name]);
   }
@@ -250,7 +250,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return sfValidatorError A sfValidatorError instance
    */
-  public function offsetGet($name)
+  public function offsetGet($name): ?sfValidatorError
   {
     return isset($this->errors[$name]) ? $this->errors[$name] : null;
   }
@@ -263,7 +263,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @throws LogicException
    */
-  public function offsetSet($offset, $value)
+  public function offsetSet($offset, $value): void
   {
     throw new LogicException('Unable update an error.');
   }
@@ -273,7 +273,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @param string $offset  (ignored)
    */
-  public function offsetUnset($offset)
+  public function offsetUnset($offset): void
   {
   }
 

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -196,7 +196,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return string The key
    */
-  public function key()
+  public function key(): string
   {
     return key($this->errors);
   }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -304,7 +304,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return string The instance as a serialized string
    */
-  public function __serialize()
+  public function __serialize(): string
   {
     return serialize(array($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors));
   }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -302,21 +302,25 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
   /**
    * Serializes the current instance.
    *
-   * @return string The instance as a serialized string
+   * @return array The instance as a serialized string
    */
-  public function __serialize(): string
+  public function __serialize(): array
   {
-    return serialize(array($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors));
+    return [
+      'validator' => $this->validator,
+      'arguments' => $this->arguments,
+      'code' => $this->code,
+      'message' => $this->message,
+      'errors' => $this->errors,
+      'globalErrors' => $this->globalErrors,
+      'namedErrors' => $this->namedErrors,
+    ];
   }
 
-  /**
-   * Unserializes a sfValidatorError instance.
-   *
-   * @param string $serialized  A serialized sfValidatorError instance
-   *
-   */
-  public function unserialize($serialized)
+  public function __unserialize(array $serialized)
   {
-    list($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors) = unserialize($serialized);
+    foreach ($serialized as $name => $values) {
+      $this->$name = $values;
+    }
   }
 }

--- a/lib/validator/sfValidatorErrorSchema.class.php
+++ b/lib/validator/sfValidatorErrorSchema.class.php
@@ -304,7 +304,7 @@ class sfValidatorErrorSchema extends sfValidatorError implements ArrayAccess, It
    *
    * @return string The instance as a serialized string
    */
-  public function serialize()
+  public function __serialize()
   {
     return serialize(array($this->validator, $this->arguments, $this->code, $this->message, $this->errors, $this->globalErrors, $this->namedErrors));
   }

--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -309,7 +309,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @return bool true if the schema has a field with the given name, false otherwise
    */
-  public function offsetExists($name)
+  public function offsetExists($name): bool
   {
     return isset($this->fields[$name]);
   }

--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -321,7 +321,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @return sfValidatorBase The sfValidatorBase instance associated with the given name, null if it does not exist
    */
-  public function offsetGet($name)
+  public function offsetGet($name): mixed
   {
     return isset($this->fields[$name]) ? $this->fields[$name] : null;
   }
@@ -332,7 +332,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    * @param string          $name       The field name
    * @param sfValidatorBase $validator  An sfValidatorBase instance
    */
-  public function offsetSet($name, $validator)
+  public function offsetSet($name, $validator): void
   {
     if (!$validator instanceof sfValidatorBase)
     {
@@ -347,7 +347,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @param string $name
    */
-  public function offsetUnset($name)
+  public function offsetUnset($name): void
   {
     unset($this->fields[$name]);
   }

--- a/lib/validator/sfValidatorSchema.class.php
+++ b/lib/validator/sfValidatorSchema.class.php
@@ -347,7 +347,7 @@ class sfValidatorSchema extends sfValidatorBase implements ArrayAccess
    *
    * @param string $name
    */
-  public function offsetUnset($name): void
+  public function offsetUnset(mixed $name): void
   {
     unset($this->fields[$name]);
   }

--- a/lib/view/sfViewCacheManager.class.php
+++ b/lib/view/sfViewCacheManager.class.php
@@ -1006,7 +1006,7 @@ class sfViewCacheManager
     if ($getParameters = $this->request->getGetParameters())
     {
       $cacheKey .= false === strpos($cacheKey, '?') ? '?' : '&';
-      $cacheKey .= http_build_query($getParameters, null, '&');
+      $cacheKey .= http_build_query($getParameters, '', '&');
     }
 
     return $cacheKey;

--- a/lib/view/sfViewParameterHolder.class.php
+++ b/lib/view/sfViewParameterHolder.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -167,7 +167,7 @@ class sfViewParameterHolder extends sfParameterHolder
    *
    * @return array Objects instance
    */
-  public function serialize()
+  public function __serialize()
   {
     return serialize(array($this->getAll(), $this->escapingMethod, $this->escaping));
   }

--- a/lib/view/sfViewParameterHolder.class.php
+++ b/lib/view/sfViewParameterHolder.class.php
@@ -164,10 +164,8 @@ class sfViewParameterHolder extends sfParameterHolder
 
   /**
    * Serializes the current instance.
-   *
-   * @return array Objects instance
    */
-  public function __serialize()
+  public function __serialize(): string
   {
     return serialize(array($this->getAll(), $this->escapingMethod, $this->escaping));
   }

--- a/lib/view/sfViewParameterHolder.class.php
+++ b/lib/view/sfViewParameterHolder.class.php
@@ -165,23 +165,25 @@ class sfViewParameterHolder extends sfParameterHolder
   /**
    * Serializes the current instance.
    */
-  public function __serialize(): string
+  public function __serialize(): array
   {
-    return serialize(array($this->getAll(), $this->escapingMethod, $this->escaping));
+    return [
+      'parameters' => $this->getAll(),
+      'escapingMethod' => $this->escapingMethod,
+      'escaping' => $this->escaping,
+    ];
   }
 
   /**
    * Unserializes a sfViewParameterHolder instance.
-   *
-   * @param string $serialized The serialized instance data
    */
-  public function unserialize($serialized)
+  public function __unserialize(array $data)
   {
-    list($this->parameters, $escapingMethod, $escaping) = unserialize($serialized);
+    $this->parameters = $data['parameters'];
 
     $this->initialize(sfContext::hasInstance() ? sfContext::getInstance()->getEventDispatcher() : new sfEventDispatcher());
 
-    $this->setEscapingMethod($escapingMethod);
-    $this->setEscaping($escaping);
+    $this->setEscapingMethod($data['escapingMethod']);
+    $this->setEscaping($data['escaping']);
   }
 }

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -710,7 +710,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @param string $name field name
    */
-  public function offsetUnset($name)
+  public function offsetUnset(mixed $name): void
   {
     unset($this->fields[$name]);
     if (false !== $position = array_search((string) $name, $this->positions))

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -684,7 +684,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *
    * @throws InvalidArgumentException when the field is not instance of sfWidget
    */
-  public function offsetSet($name, $widget)
+  public function offsetSet($name, $widget): void
   {
     if (!$widget instanceof sfWidget)
     {

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -364,7 +364,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
-  public function offsetSet($name, $widget)
+  public function offsetSet($name, $widget): void
   {
     $this->widget[$name] = $widget;
   }

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -373,7 +373,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
-  public function offsetUnset($name)
+  public function offsetUnset(mixed $name): void
   {
     unset($this->widget[$name]);
   }

--- a/test/unit/log/sfFileLoggerTest.php
+++ b/test/unit/log/sfFileLoggerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -61,7 +61,7 @@ $t->diag('option: format');
 sfToolkit::safeUnlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file));
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), date($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 sfToolkit::safeUnlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file, 'format' => '%message%'));
@@ -73,14 +73,14 @@ $t->diag('option: time_format');
 sfToolkit::safeUnlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file, 'time_format' => '%Y %m %d'));
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), date($logger->getTimeFormat()).' symfony [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 // option: type
 $t->diag('option: type');
 sfToolkit::safeUnlink($file);
 $logger = new TestLogger($dispatcher, array('file' => $file, 'type' => 'foo'));
 $logger->log('foo');
-$t->is(file_get_contents($file), strftime($logger->getTimeFormat()).' foo [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
+$t->is(file_get_contents($file), date($logger->getTimeFormat()).' foo [*6*] foo'.PHP_EOL, '->initialize() can take a format option');
 
 // ->shutdown()
 $t->diag('->shutdown()');

--- a/test/unit/response/sfResponseTest.php
+++ b/test/unit/response/sfResponseTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -12,7 +12,7 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class myResponse extends sfResponse
 {
-  function serialize() {}
+  function __serialize() {}
   function unserialize($serialized) {}
 }
 
@@ -45,8 +45,9 @@ $content = ob_get_clean();
 $t->is($content, 'test', '->sendContent() output the current response content');
 
 // ->serialize() ->unserialize()
-$t->diag('->serialize() ->unserialize()');
-$t->ok(new myResponse($dispatcher) instanceof Serializable, 'sfResponse implements the Serializable interface');
+$t->diag('->__serialize() ->__unserialize()');
+$t->ok(method_exists((new myResponse($dispatcher)), '__serialize'), 'sfResponse implements the __serialize magic method');
+$t->ok(method_exists((new myResponse($dispatcher)), '__unserialize'), 'sfResponse implements the __unserialize magic method');
 
 // new methods via sfEventDispatcher
 require_once($_test_dir.'/unit/sfEventDispatcherTest.class.php');

--- a/test/unit/response/sfResponseTest.php
+++ b/test/unit/response/sfResponseTest.php
@@ -12,8 +12,8 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class myResponse extends sfResponse
 {
-  function __serialize(): string {}
-  function unserialize($serialized) {}
+  function __serialize(): array {}
+  function __unserialize(array $serialized) {}
 }
 
 class fakeResponse

--- a/test/unit/response/sfResponseTest.php
+++ b/test/unit/response/sfResponseTest.php
@@ -12,7 +12,7 @@ require_once(__DIR__.'/../../bootstrap/unit.php');
 
 class myResponse extends sfResponse
 {
-  function __serialize() {}
+  function __serialize(): string {}
   function unserialize($serialized) {}
 }
 

--- a/test/unit/validator/sfValidatorErrorSchemaTest.php
+++ b/test/unit/validator/sfValidatorErrorSchemaTest.php
@@ -173,12 +173,11 @@ catch (LogicException $e)
   $t->pass('"sfValidatorErrorSchema" implements the ArrayAccess interface');
 }
 
-// implements Serializable
 $t->diag('implements Serializable');
 
-class NotSerializable implements Serializable
+class NotSerializable
 {
-  public function serialize()
+  public function __serialize()
   {
     throw new Exception('Not serializable');
   }

--- a/test/unit/validator/sfValidatorErrorTest.php
+++ b/test/unit/validator/sfValidatorErrorTest.php
@@ -48,15 +48,14 @@ $t->is($e->getCode(), 'max_length', '->getCode() returns the error code');
 $t->diag('__toString()');
 $t->is($e->__toString(), $e->getMessage(), '->__toString() returns the error message string');
 
-// implements Serializable
 $t->diag('implements Serializable');
 
 // we test with non serializable objects
 // to ensure that the errors are always serializable
 // even if you use PDO as a session handler
-class NotSerializable implements Serializable
+class NotSerializable
 {
-  public function serialize()
+  public function __serialize()
   {
     throw new Exception('Not serializable');
   }


### PR DESCRIPTION
- Return types
- Parameter hints
- No passing `null` where internal PHP functions expect a string
- Replace `strftime` which is deprecated in PHP 8.1
- serialization improvements
- Update Doctrine git-submodule