### PR TITLE
Fix incomplete return types

### DIFF
--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -173,9 +173,9 @@ class sfWebRequest extends sfRequest
    *
    * @return string
    */
-  public function getContentType($trim = true)
+  public function getContentType(bool $trim = true): string
   {
-    $contentType = $this->getHttpHeader('Content-Type', null);
+    $contentType = $this->getHttpHeader('Content-Type', null) ?? '';
 
     if ($trim && false !== $pos = strpos($contentType, ';'))
     {
@@ -570,9 +570,9 @@ class sfWebRequest extends sfRequest
    *
    * @param string $name The HTTP header name
    * @param string $prefix The HTTP header prefix
-   * @return string The value of HTTP header
+   * @return ?string The value of HTTP header
    */
-  public function getHttpHeader($name, $prefix = 'http')
+  public function getHttpHeader($name, $prefix = 'http'): ?string
   {
     if ($prefix)
     {

--- a/lib/util/sfToolkit.class.php
+++ b/lib/util/sfToolkit.class.php
@@ -204,9 +204,9 @@ class sfToolkit
    *
    * @param  array $value  the value to strip
    *
-   * @return array clean value with slashes stripped
+   * @return array|string clean value with slashes stripped
    */
-  public static function stripslashesDeep($value)
+  public static function stripslashesDeep($value): array|string
   {
     return is_array($value) ? array_map(array('sfToolkit', 'stripslashesDeep'), $value) : stripslashes($value);
   }


### PR DESCRIPTION
- getHttpHeader said it returns a string, but can return null as well
- stripslashesDeep said it returns an array, but can return string as well
- getContentType uses getHttpHeader, so fixed that too