### PR TITLE
Some PHP 8.2 compatibility fixes

### DIFF
--- a/lib/command/sfAnsiColorFormatter.class.php
+++ b/lib/command/sfAnsiColorFormatter.class.php
@@ -79,7 +79,7 @@ class sfAnsiColorFormatter extends sfFormatter
 
     return "\033[".implode(';', $codes).'m'.$text."\033[0m";
   }
-  
+
   /**
    * Formats a message within a section.
    *
@@ -100,7 +100,7 @@ class sfAnsiColorFormatter extends sfFormatter
     $style = array_key_exists($style, $this->styles) ? $style : 'INFO';
     $width = 9 + strlen($this->format('', $style));
 
-    return sprintf(">> %-${width}s %s", $this->format($section, $style), $this->excerpt($text, $size - 4 - (strlen($section) > 9 ? strlen($section) : 9)));
+    return sprintf(">> %-{$width}s %s", $this->format($section, $style), $this->excerpt($text, $size - 4 - (strlen($section) > 9 ? strlen($section) : 9)));
   }
 
   /**

--- a/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionListener.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/database/sfDoctrineConnectionListener.class.php
@@ -20,7 +20,10 @@
  */
 class sfDoctrineConnectionListener extends Doctrine_EventListener
 {
-  public function __construct($connection, $encoding)
+  public Doctrine_Connection $connection;
+  public string $encoding;
+
+  public function __construct(Doctrine_Connection $connection, string $encoding)
   {
     $this->connection = $connection;
     $this->encoding = $encoding;

--- a/lib/task/help/sfHelpTask.class.php
+++ b/lib/task/help/sfHelpTask.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -96,7 +96,7 @@ EOF;
       foreach ($task->getArguments() as $argument)
       {
         $default = null !== $argument->getDefault() && (!is_array($argument->getDefault()) || count($argument->getDefault())) ? $this->formatter->format(sprintf(' (default: %s)', is_array($argument->getDefault()) ? str_replace("\n", '', print_r($argument->getDefault(), true)): $argument->getDefault()), 'COMMENT') : '';
-        $messages[] = sprintf(" %-${max}s %s%s", $this->formatter->format($argument->getName(), 'INFO'), $argument->getHelp(), $default);
+        $messages[] = sprintf(" %-{$max}s %s%s", $this->formatter->format($argument->getName(), 'INFO'), $argument->getHelp(), $default);
       }
 
       $messages[] = '';

--- a/lib/task/help/sfListTask.class.php
+++ b/lib/task/help/sfListTask.class.php
@@ -120,7 +120,7 @@ EOF;
 
       $aliases = $task->getAliases() ? $this->formatter->format(' ('.implode(', ', $task->getAliases()).')', 'COMMENT') : '';
 
-      $messages[] = sprintf("  %-${width}s %s%s", $this->formatter->format(':'.$task->getName(), 'INFO'), $task->getBriefDescription(), $aliases);
+      $messages[] = sprintf("  %-{$width}s %s%s", $this->formatter->format(':'.$task->getName(), 'INFO'), $task->getBriefDescription(), $aliases);
     }
 
     $this->log($messages);


### PR DESCRIPTION
- [Creation of dynamic property is deprecated in PHP 8.2](https://github.com/Recras/symfony1/commit/241bdecd9628bc1d8b44c3371693c1e6ab2986d5)
- [${string} is deprecated in favour of {$string}](https://github.com/Recras/symfony1/commit/dc5faabc0f83f64231fabb6e4fb37d1b2637de2f)

This PR does not claim full PHP 8.2 compatibility, it just fixes some things that came up in a test