### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/lib/command/sfCommandApplication.class.php
+++ b/lib/command/sfCommandApplication.class.php
@@ -51,7 +51,7 @@ abstract class sfCommandApplication
    * @param sfFormatter       $formatter    A sfFormatter instance
    * @param array             $options      An array of options
    */
-  public function __construct(sfEventDispatcher $dispatcher, sfFormatter $formatter = null, $options = array())
+  public function __construct(?sfEventDispatcher $dispatcher, ?sfFormatter $formatter = null, array $options = [])
   {
     $this->dispatcher = $dispatcher;
     $this->formatter = null === $formatter ? $this->guessBestFormatter(STDOUT) : $formatter;

--- a/lib/command/sfCommandManager.class.php
+++ b/lib/command/sfCommandManager.class.php
@@ -39,7 +39,7 @@ class sfCommandManager
    * @param sfCommandArgumentSet $argumentSet A sfCommandArgumentSet object
    * @param sfCommandOptionSet   $optionSet   A setOptionSet object
    */
-  public function __construct(sfCommandArgumentSet $argumentSet = null, sfCommandOptionSet $optionSet = null)
+  public function __construct(?sfCommandArgumentSet $argumentSet = null, ?sfCommandOptionSet $optionSet = null)
   {
     if (null === $argumentSet)
     {

--- a/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/config/sfApplicationConfiguration.class.php
@@ -38,7 +38,7 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
    * @param string            $rootDir        The project root directory
    * @param sfEventDispatcher $dispatcher     An event dispatcher
    */
-  public function __construct($environment, $debug, $rootDir = null, sfEventDispatcher $dispatcher = null)
+  public function __construct($environment, $debug, $rootDir = null, ?sfEventDispatcher $dispatcher = null)
   {
     $this->environment = $environment;
     $this->debug       = (boolean) $debug;

--- a/lib/config/sfPluginConfiguration.class.php
+++ b/lib/config/sfPluginConfiguration.class.php
@@ -31,7 +31,7 @@ abstract class sfPluginConfiguration
    * @param string                 $rootDir       The plugin root directory
    * @param string                 $name          The plugin name
    */
-  public function __construct(sfProjectConfiguration $configuration, $rootDir = null, $name = null)
+  public function __construct(?sfProjectConfiguration $configuration, ?string $rootDir = null, ?string $name = null)
   {
     $this->configuration = $configuration;
     $this->dispatcher = $configuration->getEventDispatcher();

--- a/lib/config/sfProjectConfiguration.class.php
+++ b/lib/config/sfProjectConfiguration.class.php
@@ -602,7 +602,7 @@ class sfProjectConfiguration
    *
    * @return sfApplicationConfiguration A sfApplicationConfiguration instance
    */
-  static public function getApplicationConfiguration($application, $environment, $debug, $rootDir = null, sfEventDispatcher $dispatcher = null)
+  static public function getApplicationConfiguration($application, $environment, $debug, $rootDir = null, ?sfEventDispatcher $dispatcher = null)
   {
     $class = $application.'Configuration';
 

--- a/lib/config/sfProjectConfiguration.class.php
+++ b/lib/config/sfProjectConfiguration.class.php
@@ -43,7 +43,7 @@ class sfProjectConfiguration
    * @param string              $rootDir    The project root directory
    * @param sfEventDispatcher   $dispatcher The event dispatcher
    */
-  public function __construct($rootDir = null, sfEventDispatcher $dispatcher = null)
+  public function __construct(?string $rootDir = null, ?sfEventDispatcher $dispatcher = null)
   {
     if (null === self::$active || $this instanceof sfApplicationConfiguration)
     {

--- a/lib/debug/sfDebug.class.php
+++ b/lib/debug/sfDebug.class.php
@@ -107,7 +107,7 @@ class sfDebug
    *
    * @return array The request parameter holders
    */
-  public static function requestAsArray(sfRequest $request = null)
+  public static function requestAsArray(?sfRequest $request = null)
   {
     if (!$request)
     {
@@ -128,7 +128,7 @@ class sfDebug
    *
    * @return array The response parameters
    */
-  public static function responseAsArray(sfResponse $response = null)
+  public static function responseAsArray(?sfResponse $response = null)
   {
     if (!$response)
     {
@@ -154,7 +154,7 @@ class sfDebug
    *
    * @return array The user parameters
    */
-  public static function userAsArray(sfUser $user = null)
+  public static function userAsArray(?sfUser $user = null)
   {
     if (!$user)
     {

--- a/lib/form/addon/sfFormSymfony.class.php
+++ b/lib/form/addon/sfFormSymfony.class.php
@@ -42,10 +42,8 @@ class sfFormSymfony extends sfForm
 
   /**
    * Sets the event dispatcher to be used by all forms.
-   *
-   * @param sfEventDispatcher $dispatcher
    */
-  static public function setEventDispatcher(sfEventDispatcher $dispatcher = null)
+  static public function setEventDispatcher(?sfEventDispatcher $dispatcher = null)
   {
     self::$dispatcher = $dispatcher;
   }

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -205,7 +205,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    * @param array $taintedValues  An array of input values
    * @param array $taintedFiles   An array of uploaded files (in the $_FILES or $_GET format)
    */
-  public function bind(array $taintedValues = null, array $taintedFiles = null)
+  public function bind(?array $taintedValues = null, ?array $taintedFiles = null)
   {
     $this->taintedValues = $taintedValues;
     $this->taintedFiles  = $taintedFiles;
@@ -265,7 +265,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    * @param array $taintedValues
    * @param array $taintedFiles
    */
-  public function bindEmbeddedForms(array $taintedValues = null, array $taintedFiles = null)
+  public function bindEmbeddedForms(?array $taintedValues = null, ?array $taintedFiles = null)
   {
     foreach ($this->embeddedForms as $name => $form)
     {
@@ -446,7 +446,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    * @param sfForm $form       A sfForm instance
    * @param string $decorator  A HTML decorator for the embedded form
    */
-  public function embedForm($name, sfForm $form, $decorator = null)
+  public function embedForm($name, ?sfForm $form, ?string $decorator = null)
   {
     $name = (string) $name;
     if (true === $this->isBound() || true === $form->isBound())
@@ -546,7 +546,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param sfValidatorBase $validator A validator to be merged
    */
-  public function mergePreValidator(sfValidatorBase $validator = null)
+  public function mergePreValidator(?sfValidatorBase $validator = null)
   {
     if (null === $validator)
     {
@@ -571,7 +571,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param sfValidatorBase $validator A validator to be merged
    */
-  public function mergePostValidator(sfValidatorBase $validator = null)
+  public function mergePostValidator(?sfValidatorBase $validator = null)
   {
     if (null === $validator)
     {

--- a/lib/form/sfFormField.class.php
+++ b/lib/form/sfFormField.class.php
@@ -20,7 +20,7 @@ class sfFormField
 {
   protected static
     $toStringException = null;
-  
+
   /** @var sfWidgetForm */
   protected $widget = null;
   /** @var null|sfFormField */
@@ -41,7 +41,7 @@ class sfFormField
    * @param string           $value  The field value
    * @param sfValidatorError $error  A sfValidatorError instance
    */
-  public function __construct(sfWidgetForm $widget, sfFormField $parent = null, $name, $value, sfValidatorError $error = null)
+  public function __construct(?sfWidgetForm $widget, ?sfFormField $parent = null, string $name, string $value, ?sfValidatorError $error = null)
   {
     $this->widget = $widget;
     $this->parent = $parent;
@@ -327,7 +327,7 @@ class sfFormField
     if ($this->error instanceof sfValidatorErrorSchema) {
       return $this->error->count() > 0;
     }
-    
+
     return $this->error !== null;
   }
 }

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -32,7 +32,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    * @param string             $value  The field value
    * @param sfValidatorError   $error  A sfValidatorError instance
    */
-  public function __construct(sfWidgetFormSchema $widget, sfFormField $parent = null, $name, $value, sfValidatorError $error = null)
+  public function __construct(sfWidgetFormSchema $widget, ?sfFormField $parent = null, $name, $value, ?sfValidatorError $error = null)
   {
     parent::__construct($widget, $parent, $name, $value, $error);
 

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -32,7 +32,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    * @param string             $value  The field value
    * @param sfValidatorError   $error  A sfValidatorError instance
    */
-  public function __construct(sfWidgetFormSchema $widget, ?sfFormField $parent = null, $name, $value, ?sfValidatorError $error = null)
+  public function __construct(?sfWidgetFormSchema $widget, ?sfFormField $parent = null, string $name, string $value, ?sfValidatorError $error = null)
   {
     parent::__construct($widget, $parent, $name, $value, $error);
 

--- a/lib/form/sfFormFieldSchema.class.php
+++ b/lib/form/sfFormFieldSchema.class.php
@@ -32,7 +32,7 @@ class sfFormFieldSchema extends sfFormField implements ArrayAccess, Iterator, Co
    * @param string             $value  The field value
    * @param sfValidatorError   $error  A sfValidatorError instance
    */
-  public function __construct(?sfWidgetFormSchema $widget, ?sfFormField $parent = null, string $name, string $value, ?sfValidatorError $error = null)
+  public function __construct(?sfWidgetFormSchema $widget, ?sfFormField $parent = null, ?string $name = null, string $value, ?sfValidatorError $error = null)
   {
     parent::__construct($widget, $parent, $name, $value, $error);
 

--- a/lib/generator/sfGeneratorManager.class.php
+++ b/lib/generator/sfGeneratorManager.class.php
@@ -28,7 +28,7 @@ class sfGeneratorManager
    * @param sfProjectConfiguration $configuration A sfProjectConfiguration instance
    * @param string                 $basePath      The base path for file generation
    */
-  public function __construct(sfProjectConfiguration $configuration, $basePath = null)
+  public function __construct(?sfProjectConfiguration $configuration, $basePath = null)
   {
     $this->configuration = $configuration;
     $this->basePath = $basePath;

--- a/lib/i18n/sfI18N.class.php
+++ b/lib/i18n/sfI18N.class.php
@@ -32,7 +32,7 @@ class sfI18N
    *
    * @see initialize()
    */
-  public function __construct(sfApplicationConfiguration $configuration, sfCache $cache = null, $options = array())
+  public function __construct(?sfApplicationConfiguration $configuration, ?sfCache $cache = null, array $options = [])
   {
     $this->initialize($configuration, $cache, $options);
   }
@@ -53,7 +53,7 @@ class sfI18N
    * @param sfCache                    $cache           A sfCache instance
    * @param array                      $options         An array of options
    */
-  public function initialize(sfApplicationConfiguration $configuration, sfCache $cache = null, $options = array()): void
+  public function initialize(?sfApplicationConfiguration $configuration, ?sfCache $cache = null, array $options = []): void
   {
     $this->configuration = $configuration;
     $this->dispatcher = $configuration->getEventDispatcher();

--- a/lib/plugins/sfDoctrinePlugin/lib/form/sfFormDoctrine.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/form/sfFormDoctrine.class.php
@@ -377,7 +377,7 @@ abstract class sfFormDoctrine extends sfFormObject
    *
    * @return string The filename used to save the file
    */
-  protected function saveFile($field, $filename = null, sfValidatedFile $file = null)
+  protected function saveFile(string $field, ?string $filename = null, ?sfValidatedFile $file = null)
   {
     if (!$this->validatorSchema[$field] instanceof sfValidatorFile)
     {

--- a/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpool.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/mailer/Swift_DoctrineSpool.class.php
@@ -84,7 +84,7 @@ class Swift_DoctrineSpool extends Swift_ConfigurableSpool
 
     $object->{$this->column} = serialize($message);
     $object->save();
-    
+
     $object->free(true);
   }
 
@@ -96,7 +96,7 @@ class Swift_DoctrineSpool extends Swift_ConfigurableSpool
    *
    * @return int The number of sent emails
    */
-  public function flushQueue(Swift_Transport $transport, &$failedRecipients = null)
+  public function flushQueue(?Swift_Transport $transport, &$failedRecipients = null)
   {
     $table = Doctrine_Core::getTable($this->model);
     $objects = $table->{$this->method}()->limit($this->getMessageLimit())->execute();

--- a/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecord.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/record/sfDoctrineRecord.class.php
@@ -240,7 +240,7 @@ abstract class sfDoctrineRecord extends Doctrine_Record
    * @return sfDoctrineRecord
    * @throws sfException if the field is not one of date, datetime, or timestamp types
    */
-  public function setDateTimeObject($dateFieldName, DateTime $dateTimeObject = null)
+  public function setDateTimeObject($dateFieldName, ?DateTime $dateTimeObject = null)
   {
     $type = $this->getTable()->getTypeOf($dateFieldName);
     if ($type == 'date' || $type == 'timestamp' || $type == 'datetime')

--- a/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineBaseTask.class.php
+++ b/lib/plugins/sfDoctrinePlugin/lib/task/sfDoctrineBaseTask.class.php
@@ -71,10 +71,10 @@ abstract class sfDoctrineBaseTask extends sfBaseTask
    * @param array|null        $names An array of names or NULL for all databases
    *
    * @return array An associative array of {@link sfDoctrineDatabase} objects and their names
-   * 
+   *
    * @throws InvalidArgumentException If a requested database is not a Doctrine database
    */
-  protected function getDoctrineDatabases(sfDatabaseManager $databaseManager, array $names = null)
+  protected function getDoctrineDatabases(?sfDatabaseManager $databaseManager, ?array $names = null)
   {
     $databases = array();
 
@@ -200,7 +200,7 @@ abstract class sfDoctrineBaseTask extends sfBaseTask
    * @param array $models An array of model definitions
    *
    * @return array An array of globals
-   * 
+   *
    * @see Doctrine_Import_Schema::getGlobalDefinitionKeys()
    */
   protected function filterSchemaGlobals(& $models)
@@ -222,10 +222,10 @@ abstract class sfDoctrineBaseTask extends sfBaseTask
 
   /**
    * Canonicalizes a model definition in preparation for merging.
-   * 
+   *
    * @param string $model      The model name
    * @param array  $definition The model definition
-   * 
+   *
    * @return array The canonicalized model definition
    */
   protected function canonicalizeModelDefinition($model, $definition)

--- a/lib/plugins/sfDoctrinePlugin/test/functional/fixtures/lib/model/doctrine/ArticleTable.class.php
+++ b/lib/plugins/sfDoctrinePlugin/test/functional/fixtures/lib/model/doctrine/ArticleTable.class.php
@@ -52,7 +52,7 @@ class ArticleTable extends Doctrine_Table
     return $this->createQuery()->select('title, body');
   }
 
-  public function addOnHomepage(Doctrine_Query $q = null)
+  public function addOnHomepage(?Doctrine_Query $q = null)
   {
     if (is_null($q))
     {

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -434,7 +434,7 @@ class sfWebRequest extends sfRequest
    *
    * @return string The preferred culture
    */
-  public function getPreferredCulture(array $cultures = null)
+  public function getPreferredCulture(?array $cultures = null)
   {
     $preferredCultures = $this->getLanguages();
 

--- a/lib/routing/sfPatternRouting.class.php
+++ b/lib/routing/sfPatternRouting.class.php
@@ -46,7 +46,7 @@ class sfPatternRouting extends sfRouting
    * @see sfRouting
    * @inheritdoc
    */
-  public function initialize(sfEventDispatcher $dispatcher, sfCache $cache = null, $options = array()): void
+  public function initialize(sfEventDispatcher $dispatcher, ?sfCache $cache = null, $options = array()): void
   {
     $options = array_merge(array(
       'variable_prefixes'                => array(':'),

--- a/lib/routing/sfRouting.class.php
+++ b/lib/routing/sfRouting.class.php
@@ -34,7 +34,7 @@ abstract class sfRouting
    * @param sfCache           $cache
    * @param array             $options
    */
-  public function __construct(sfEventDispatcher $dispatcher, sfCache $cache = null, $options = array())
+  public function __construct(sfEventDispatcher $dispatcher, ?sfCache $cache = null, $options = array())
   {
     $this->initialize($dispatcher, $cache, $options);
 
@@ -69,7 +69,7 @@ abstract class sfRouting
    * @param sfCache           $cache       An sfCache instance
    * @param array             $options     An associative array of initialization options.
    */
-  public function initialize(sfEventDispatcher $dispatcher, sfCache $cache = null, $options = array()): void
+  public function initialize(sfEventDispatcher $dispatcher, ?sfCache $cache = null, $options = array()): void
   {
     $this->dispatcher = $dispatcher;
 

--- a/lib/service/sfServiceContainerLoader.class.php
+++ b/lib/service/sfServiceContainerLoader.class.php
@@ -25,7 +25,7 @@ abstract class sfServiceContainerLoader implements sfServiceContainerLoaderInter
    *
    * @param sfServiceContainerBuilder $container A sfServiceContainerBuilder instance
    */
-  public function __construct(sfServiceContainerBuilder $container = null)
+  public function __construct(?sfServiceContainerBuilder $container = null)
   {
     $this->container = $container;
   }

--- a/lib/task/sfBaseTask.class.php
+++ b/lib/task/sfBaseTask.class.php
@@ -80,7 +80,7 @@ abstract class sfBaseTask extends sfCommandApplicationTask
    *
    * @param sfProjectConfiguration $configuration
    */
-  public function setConfiguration(sfProjectConfiguration $configuration = null)
+  public function setConfiguration(?sfProjectConfiguration $configuration = null)
   {
     $this->configuration = $configuration;
   }

--- a/lib/task/sfCommandApplicationTask.class.php
+++ b/lib/task/sfCommandApplicationTask.class.php
@@ -34,7 +34,7 @@ abstract class sfCommandApplicationTask extends sfTask
    *
    * @param sfCommandApplication $commandApplication A sfCommandApplication instance
    */
-  public function setCommandApplication(sfCommandApplication $commandApplication = null)
+  public function setCommandApplication(?sfCommandApplication $commandApplication = null)
   {
     $this->commandApplication = $commandApplication;
   }

--- a/lib/task/sfFilesystem.class.php
+++ b/lib/task/sfFilesystem.class.php
@@ -28,7 +28,7 @@ class sfFilesystem
    * @param sfEventDispatcher $dispatcher  An sfEventDispatcher instance
    * @param sfFormatter       $formatter   An sfFormatter instance
    */
-  public function __construct(sfEventDispatcher $dispatcher = null, sfFormatter $formatter = null)
+  public function __construct(?sfEventDispatcher $dispatcher = null, ?sfFormatter $formatter = null)
   {
     $this->dispatcher = $dispatcher;
     $this->formatter = $formatter;

--- a/lib/widget/sfWidgetForm.class.php
+++ b/lib/widget/sfWidgetForm.class.php
@@ -282,7 +282,7 @@ abstract class sfWidgetForm extends sfWidget
    *
    * @return sfWidgetForm The current widget instance
    */
-  public function setParent(sfWidgetFormSchema $widgetSchema = null)
+  public function setParent(?sfWidgetFormSchema $widgetSchema = null)
   {
     $this->parent = $widgetSchema;
 

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -297,7 +297,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
    * @see sfWidgetFormSchema
    * @inheritdoc
    */
-  public function setParent(sfWidgetFormSchema $parent = null)
+  public function setParent(?sfWidgetFormSchema $parent = null)
   {
     $this->widget->setParent($parent);
 

--- a/test/unit/routing/sfPatternRoutingTest.php
+++ b/test/unit/routing/sfPatternRoutingTest.php
@@ -14,7 +14,7 @@ $t = new lime_test(149);
 
 class sfPatternRoutingTest extends sfPatternRouting
 {
-  public function initialize(sfEventDispatcher $dispatcher, sfCache $cache = null, $options = array()): void
+  public function initialize(sfEventDispatcher $dispatcher, ?sfCache $cache = null, $options = array()): void
   {
     parent::initialize($dispatcher, $cache, $options);
 


### PR DESCRIPTION
Implicitly marking parameters as nullable is deprecated in PHP 8.4